### PR TITLE
Allow kyverno Helm repo in 'local' AppProject sourceRepos

### DIFF
--- a/helm-argocd/environments/cloud/main.yaml
+++ b/helm-argocd/environments/cloud/main.yaml
@@ -15,6 +15,7 @@ spec:
         - https://*.github.com/*
         - https://stakater.github.io/stakater-charts
         - https://cloudhippie.github.io/charts
+        - https://kyverno.github.io/kyverno/
     destinations:
         - namespace: '*'
           server: https://kubernetes.default.svc


### PR DESCRIPTION
The https://*.github.io/* glob doesn't match Helm chart repos here in practice (same reason every other *.github.io source already has its own explicit entry) — kyverno app was failing sync with InvalidSpecError: repo not permitted in project 'local'.